### PR TITLE
[웹 서버 2단계] 김현원 제출합니다.

### DIFF
--- a/src/main/java/http/HttpMethod.java
+++ b/src/main/java/http/HttpMethod.java
@@ -1,0 +1,25 @@
+package http;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum HttpMethod {
+    GET("GET"), POST("POST"), PUT("PUT"), DELETE("DELETE");
+
+    String methodName;
+    private static final Map<String, HttpMethod> httpMethods = new HashMap<>();
+
+    HttpMethod(String methodName) {
+        this.methodName = methodName;
+    }
+
+    static{
+        for(HttpMethod httpMethod: HttpMethod.values()){
+            httpMethods.put(httpMethod.methodName, httpMethod);
+        }
+    }
+
+    public static HttpMethod getHttpMethod(String methodName){
+        return httpMethods.get(methodName);
+    }
+}

--- a/src/main/java/http/HttpRequest.java
+++ b/src/main/java/http/HttpRequest.java
@@ -1,0 +1,43 @@
+package http;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpRequest {
+    private HttpMethod method;
+    private String path;
+    private String protocol;
+    private final Map<String, String> headers = new HashMap<>();
+
+    public HttpRequest(){}
+
+    public HttpMethod getMethod(){
+        return this.method;
+    }
+
+    public String getPath(){
+        return this.path;
+    }
+
+    public String getProtocol(){
+        return this.protocol;
+    }
+
+    public void setMethod(String methodName){
+        HttpMethod httpMethod;
+        // 모든 http 메소드를 등록한 것이 아니기 때문에 존재하지 않은 메서드가 들어왔을 때 GET으로 처리한다.
+        if((httpMethod = HttpMethod.getHttpMethod(methodName)) == null) {
+            this.method = HttpMethod.GET;
+            return;
+        }
+        this.method = httpMethod;
+    }
+
+    public void setPath(String path){
+        this.path = path;
+    }
+
+    public void setProtocol(String protocol){
+        this.protocol = protocol;
+    }
+}

--- a/src/main/java/http/HttpRequestResolver.java
+++ b/src/main/java/http/HttpRequestResolver.java
@@ -1,0 +1,44 @@
+package http;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import util.StaticFileProvider;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+
+public class HttpRequestResolver {
+    private static final Logger logger = LoggerFactory.getLogger(HttpRequestResolver.class);
+    private static final HttpRequestResolver INSTANCE = new HttpRequestResolver();
+
+    public static HttpRequestResolver getInstance(){
+        return INSTANCE;
+    }
+
+    public HttpRequest parseHttpRequest(BufferedReader br) throws IOException {
+        HttpRequest httpRequest = new HttpRequest();
+
+        String line = br.readLine();
+        logger.debug("request line: {}", line);
+
+        parseHttpRequestLine(line, httpRequest);
+
+        // 요청 헤더 읽기
+        while((line = br.readLine()) != null){
+            if(line.isBlank()){
+                break;
+            }
+            logger.debug("header: {}", line);
+        }
+
+        return httpRequest;
+    }
+
+    private void parseHttpRequestLine(String requestLine, HttpRequest httpRequest){
+        String[] requestLineParts = requestLine.split(" ");
+
+        httpRequest.setMethod(requestLineParts[0]);
+        httpRequest.setPath(requestLineParts[1]);
+        httpRequest.setProtocol(requestLineParts[2]);
+    }
+}

--- a/src/main/java/http/HttpResponseResolver.java
+++ b/src/main/java/http/HttpResponseResolver.java
@@ -1,0 +1,47 @@
+package http;
+
+import model.Mime;
+import util.StaticFileProvider;
+
+import javax.swing.*;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class HttpResponseResolver {
+    private static final HttpResponseResolver INSTANCE = new HttpResponseResolver();
+
+    public static HttpResponseResolver getInstance(){
+        return INSTANCE;
+    }
+    public HttpResponseResolver(){
+    }
+
+    public void send200Response(DataOutputStream dos, String path, byte[] data) throws IOException {
+        String extension = StaticFileProvider.extractFileExtension(path);
+        String contentType = Mime.getMimeType(extension);
+
+        writeHeader(dos, HttpStatus.OK, contentType, data.length);
+        writeBody(dos, data);
+    }
+
+    public void send404Response(DataOutputStream dos) throws IOException{
+        String responseData = "Request file Not Found";
+
+        byte[] byteData = responseData.getBytes();
+
+        writeHeader(dos, HttpStatus.NOT_FOUND, "text/plain", byteData.length);
+        writeBody(dos, byteData);
+    }
+
+    private void writeHeader(DataOutputStream dos, HttpStatus httpStatus, String contentType, int contentLength) throws IOException {
+        dos.writeBytes(String.format("HTTP/1.1 {} {}\r\n", httpStatus.getStatusCode(), httpStatus.getReasonPhrase()));
+        dos.writeBytes(String.format("Content-Type: %s;charset=utf-8\r\n", contentType));
+        dos.writeBytes(String.format("Content-Length: %d\r\n", contentLength));
+        dos.writeBytes("\r\n");
+    }
+
+    private void writeBody(DataOutputStream dos, byte[] data) throws IOException {
+        dos.write(data, 0, data.length);
+        dos.flush();
+    }
+}

--- a/src/main/java/http/HttpStatus.java
+++ b/src/main/java/http/HttpStatus.java
@@ -1,0 +1,21 @@
+package http;
+
+public enum HttpStatus {
+    OK(200, "OK"), NOT_FOUND(404, "Not Found");
+
+    private int statusCode;
+    private String reasonPhrase;
+
+    HttpStatus(int statusCode, String reasonPhrase){
+        this.statusCode = statusCode;
+        this.reasonPhrase = reasonPhrase;
+    }
+
+    public int getStatusCode(){
+        return this.statusCode;
+    }
+
+    public String getReasonPhrase(){
+        return this.reasonPhrase;
+    }
+}

--- a/src/main/java/model/Mime.java
+++ b/src/main/java/model/Mime.java
@@ -5,11 +5,12 @@ import java.util.Map;
 
 public enum Mime {
     TEXT_HTML("html", "text/html"),
-    TEXT_CSS("css", "test/css"),
+    TEXT_CSS("css", "text/css"),
     TEXT_JAVASCRIPT("js", "text/js"),
     IMAGE_VND_MICROSOFT_ICON("ico", "image/vnd.microsoft.icon"),
     IMAGE_JPEG("jpeg", "image/jpeg"),
-    IMAGE_PNG("png", "image/png");
+    IMAGE_PNG("png", "image/png"),
+    IMAGE_SVG_XML("svg", "image/svg+xml");
 
     private String extension;
     private final String type;

--- a/src/main/java/model/Mime.java
+++ b/src/main/java/model/Mime.java
@@ -15,6 +15,7 @@ public enum Mime {
     private String extension;
     private final String type;
     private static final Map<String, Mime> extensionToMimeMap = new HashMap<>();
+    private static final String defaultMimeType = "application/octet-stream";
 
     static{
         for(Mime mime: Mime.values()){
@@ -32,6 +33,6 @@ public enum Mime {
         if(mime != null){
             return mime.type;
         }
-        return null;
+        return defaultMimeType;
     }
 }

--- a/src/main/java/model/Mime.java
+++ b/src/main/java/model/Mime.java
@@ -1,0 +1,36 @@
+package model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum Mime {
+    TEXT_HTML("html", "text/html"),
+    TEXT_CSS("css", "test/css"),
+    TEXT_JAVASCRIPT("js", "text/js"),
+    IMAGE_VND_MICROSOFT_ICON("ico", "image/vnd.microsoft.icon"),
+    IMAGE_JPEG("jpeg", "image/jpeg"),
+    IMAGE_PNG("png", "image/png");
+
+    private String extension;
+    private final String type;
+    private static final Map<String, Mime> extensionToMimeMap = new HashMap<>();
+
+    static{
+        for(Mime mime: Mime.values()){
+            extensionToMimeMap.put(mime.extension, mime);
+        }
+    }
+
+    Mime(String extension, String type) {
+        this.extension = extension;
+        this.type = type;
+    }
+
+    public static String getMimeType(String extension){
+        Mime mime = extensionToMimeMap.get(extension);
+        if(mime != null){
+            return mime.type;
+        }
+        return null;
+    }
+}

--- a/src/main/java/util/StaticFileProvider.java
+++ b/src/main/java/util/StaticFileProvider.java
@@ -17,7 +17,8 @@ public class StaticFileProvider {
 
         File file = new File(filePath);
 
-        if(file.exists()){
+        // 파일 객체가 존재하는 지만 확인하는 것이 아닌 해당 파일 객체가 디렉토리인지 확인하는 과정이 필요하다.
+        if(file.exists() && !file.isDirectory()){
             return file;
         }
 

--- a/src/main/java/util/StaticFileProvider.java
+++ b/src/main/java/util/StaticFileProvider.java
@@ -43,4 +43,9 @@ public class StaticFileProvider {
 
         return null;
     }
+
+    public static String extractFileExtension(String path){
+        String[] pathParts = path.split("\\.");
+        return pathParts[pathParts.length - 1];
+    }
 }

--- a/src/main/java/util/StaticFileProvider.java
+++ b/src/main/java/util/StaticFileProvider.java
@@ -29,7 +29,7 @@ public class StaticFileProvider {
         try (FileInputStream fis = new FileInputStream(file);
              ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ) {
-            byte[] buffer = new byte[1024];
+            byte[] buffer = new byte[8192];
             int bytesRead;
 
             while ((bytesRead = fis.read(buffer)) != -1) {

--- a/src/main/java/util/StaticFileProvider.java
+++ b/src/main/java/util/StaticFileProvider.java
@@ -12,8 +12,8 @@ public class StaticFileProvider {
     private static final Logger logger = LoggerFactory.getLogger(StaticFileProvider.class);
     private static final String BASE_DIRECTORY = "./src/main/resources/static/";
 
-    public static File findStaticFileByUrl(String url) {
-        String filePath = BASE_DIRECTORY + url;
+    public static File findStaticFileByPath(String path) {
+        String filePath = BASE_DIRECTORY + path;
 
         File file = new File(filePath);
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -3,6 +3,7 @@ package webserver;
 import java.io.*;
 import java.net.Socket;
 
+import model.Mime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import util.StaticFileProvider;
@@ -24,13 +25,13 @@ public class RequestHandler implements Runnable {
             BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
             DataOutputStream dos = new DataOutputStream(out);
             byte[] body = null;
-            String url = null;
+            String path = null;
 
             String line = br.readLine();
             logger.debug("request line : {}", line);
 
-            if ((url = parseRequestPath(line)) != null) {
-                File resultFile = StaticFileProvider.findStaticFileByUrl(url);
+            if ((path = parseRequestPath(line)) != null) {
+                File resultFile = StaticFileProvider.findStaticFileByPath(path);
 
                 if (resultFile == null) {
                     throw new RuntimeException("해당 경로에 해당하는 파일이 없습니다.");
@@ -43,21 +44,35 @@ public class RequestHandler implements Runnable {
                 logger.debug("header:  {}", line);
             }
 
-            response200Header(dos, body.length);
+            String extension = extractFileExtension(path);
+
+            String mimeType = Mime.getMimeType(extension);
+
+            if(mimeType == null){
+                throw new RuntimeException("파일 확장자에 해당하는 MIME 타입이 없습니다.");
+            }
+
+            response200Header(dos, mimeType, body.length);
             responseBody(dos, body);
         } catch (IOException | RuntimeException e) {
             logger.error(e.getMessage());
         }
     }
+
     private String parseRequestPath(String requestFirstLine){
         String[] requestParts = requestFirstLine.split(" ");
         return requestParts[1];
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private String extractFileExtension(String path){
+        String[] pathParts = path.split("\\.");
+        return pathParts[pathParts.length - 1];
+    }
+
+    private void response200Header(DataOutputStream dos, String mimeType, int lengthOfBodyContent) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes(String.format("Content-Type: %s;charset=utf-8\r\n", mimeType));
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -3,14 +3,15 @@ package webserver;
 import java.io.*;
 import java.net.Socket;
 
-import model.Mime;
+import http.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import util.StaticFileProvider;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
-
+    private final HttpRequestResolver httpRequestResolver = HttpRequestResolver.getInstance();
+    private final HttpResponseResolver httpResponseResolver = HttpResponseResolver.getInstance();
     private Socket connection;
 
     public RequestHandler(Socket connectionSocket) {
@@ -21,71 +22,24 @@ public class RequestHandler implements Runnable {
         logger.debug("New Client Connect! Connected IP : {}, Port : {}", connection.getInetAddress(),
                 connection.getPort());
 
-        try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
+        try (InputStream in = connection.getInputStream();OutputStream out = connection.getOutputStream()) {
             BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = null;
-            String path = null;
 
-            String line = br.readLine();
-            logger.debug("request line : {}", line);
+            HttpRequest httpRequest = httpRequestResolver.parseHttpRequest(br);
 
-            if ((path = parseRequestPath(line)) != null) {
-                File resultFile = StaticFileProvider.findStaticFileByPath(path);
+            File resultFile = StaticFileProvider.findStaticFileByPath(httpRequest.getPath());
 
-                if (resultFile == null) {
-                    throw new RuntimeException("해당 경로에 해당하는 파일이 없습니다.");
-                }
-                body = StaticFileProvider.readStaticFileToByteArray(resultFile);
+            if(resultFile != null){
+                byte[] data = StaticFileProvider.readStaticFileToByteArray(resultFile);
+                httpResponseResolver.send200Response(dos, httpRequest.getPath(), data);
+            }else{
+                httpResponseResolver.send404Response(dos);
             }
-
-            while (!line.equals("")) {
-                line = br.readLine();
-                logger.debug("header:  {}", line);
-            }
-
-            String extension = extractFileExtension(path);
-
-            String mimeType = Mime.getMimeType(extension);
-
-            if(mimeType == null){
-                throw new RuntimeException("파일 확장자에 해당하는 MIME 타입이 없습니다.");
-            }
-
-            response200Header(dos, mimeType, body.length);
-            responseBody(dos, body);
-        } catch (IOException | RuntimeException e) {
+        }
+        catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
 
-    private String parseRequestPath(String requestFirstLine){
-        String[] requestParts = requestFirstLine.split(" ");
-        return requestParts[1];
-    }
-
-    private String extractFileExtension(String path){
-        String[] pathParts = path.split("\\.");
-        return pathParts[pathParts.length - 1];
-    }
-
-    private void response200Header(DataOutputStream dos, String mimeType, int lengthOfBodyContent) {
-        try {
-            dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes(String.format("Content-Type: %s;charset=utf-8\r\n", mimeType));
-            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void responseBody(DataOutputStream dos, byte[] body) {
-        try {
-            dos.write(body, 0, body.length);
-            dos.flush();
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
 }


### PR DESCRIPTION
1. Mime 타입 처리
- 기존 코드에서는 text/html 를 제외한 나머지 MimeType 에 해당하는 데이터를 처리하지 못한다. 요구사항에 존재하는 MimeType 을 해결할 수 있도록 한다.
- Mime 타입에 대한 enum 클래스를 작성한다. 확장자에 해당하는 MimeType 을 찾기 위해서 MimeType 내부에 HashMap 를 설정하고 상수 시간 안에 찾을 수 있도록 한다.

2. http 요청, 응답 리팩토링
- 기존 코드의 RequestHandler 에서 처리한 부분을 책임에 맞는 클래스로 분리한다. 