### PR TITLE
[웹 서버 2단계] 송지웅

### DIFF
--- a/src/main/java/resolver/ResourceResolver.java
+++ b/src/main/java/resolver/ResourceResolver.java
@@ -1,7 +1,8 @@
 package resolver;
 
 import webserver.message.HTTPRequest;
+import webserver.message.HTTPResponse;
 
 public interface ResourceResolver {
-    byte [] resolve(HTTPRequest request);
+    void resolve(HTTPRequest request, HTTPResponse.Builder response);
 }

--- a/src/main/java/resolver/ResourceResolver.java
+++ b/src/main/java/resolver/ResourceResolver.java
@@ -1,5 +1,7 @@
 package resolver;
 
+import webserver.message.HTTPRequest;
+
 public interface ResourceResolver {
-    byte [] resolve(String url);
+    byte [] resolve(HTTPRequest request);
 }

--- a/src/main/java/resolver/StaticResourceResolver.java
+++ b/src/main/java/resolver/StaticResourceResolver.java
@@ -3,18 +3,25 @@ package resolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.RequestHandler;
+import webserver.enumeration.HTTPContentType;
 import webserver.message.HTTPRequest;
+import webserver.message.header.records.AcceptRecord;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class StaticResourceResolver implements ResourceResolver {
     private static final ClassLoader classLoader = RequestHandler.class.getClassLoader();
     private static final StaticResourceResolver instance = new StaticResourceResolver();
     private static final Logger logger = LoggerFactory.getLogger(StaticResourceResolver.class);
+
+    private static final Pattern EXT_PATTERN = Pattern.compile("(\\.\\w+)$");
+
     private StaticResourceResolver() {}
 
     public static StaticResourceResolver getInstance() {
@@ -23,25 +30,60 @@ public class StaticResourceResolver implements ResourceResolver {
 
     @Override
     public byte[] resolve(HTTPRequest request) {
-        Optional<String> resource = findResource(request.getUri());
-        if (resource.isEmpty()) {
-            return "NOT FOUND".getBytes();
-        }
+        String url = request.getUri();
+        url = url.startsWith("/") ? url.replaceFirst("/", "static/"): url;
         try {
-            return Files.readAllBytes(new File(resource.get()).toPath());
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-            return "SERVER ERROR".getBytes();
+            Optional<byte []> acceptTypedFile = tryAcceptTypedFile(request, url);
+            if (acceptTypedFile.isPresent()) {
+                return acceptTypedFile.get();
+            }
+            Optional<byte[]> namedFile = loadResourceAsBytes(url);
+            return namedFile.orElseGet("NOT FOUND"::getBytes);
+        } catch (IOException ioException) {
+            logger.error(ioException.getMessage());
+            return "INTERNAL SERVER ERROR".getBytes();
         }
     }
 
-    private Optional<String> findResource(String url) {
-        url = url.startsWith("/") ? url.replaceFirst("/", "static/"): url;
-        URL resource = classLoader.getResource(url);
+    private Optional<byte []> tryAcceptTypedFile(HTTPRequest request, String url) throws IOException {
+        Optional<AcceptRecord[]> optionalHeader = request.getHeader("accept", AcceptRecord[].class);
+        if (optionalHeader.isEmpty()) {
+            return Optional.empty();
+        }
+        AcceptRecord[] acceptHeaders = optionalHeader.get();
+        Matcher matcher = EXT_PATTERN.matcher(url);
+        for (AcceptRecord acceptHeader : acceptHeaders) {
+            Optional<byte[]> filePath = tryFindAcceptType(acceptHeader.type(), matcher);
+            if (filePath.isEmpty()) {
+                continue;
+            }
+            return filePath;
+        }
+        return Optional.empty();
+    }
+
+    private Optional<byte []> tryFindAcceptType(HTTPContentType contentType, Matcher matcher) throws IOException {
+        String acceptUrl = matcher.replaceFirst(contentType.detail);
+        Optional<byte[]> filePath = loadResourceAsBytes(acceptUrl);
+        if (filePath.isPresent()) {
+            return filePath;
+        }
+        for (String alias : contentType.alias) {
+            acceptUrl = matcher.replaceFirst(alias);
+            filePath = loadResourceAsBytes(acceptUrl);
+            if (filePath.isPresent()) {
+                return filePath;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<byte[]> loadResourceAsBytes(String acceptUrl) throws IOException {
+        URL resource = classLoader.getResource(acceptUrl);
         if (resource == null) {
             return Optional.empty();
         }
         String filePath = resource.getFile();
-        return Optional.of(filePath);
+        return Optional.of(Files.readAllBytes(new File(filePath).toPath()));
     }
 }

--- a/src/main/java/resolver/StaticResourceResolver.java
+++ b/src/main/java/resolver/StaticResourceResolver.java
@@ -3,6 +3,7 @@ package resolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.RequestHandler;
+import webserver.message.HTTPRequest;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,8 +22,8 @@ public class StaticResourceResolver implements ResourceResolver {
     }
 
     @Override
-    public byte[] resolve(String url) {
-        Optional<String> resource = findResource(url);
+    public byte[] resolve(HTTPRequest request) {
+        Optional<String> resource = findResource(request.getUri());
         if (resource.isEmpty()) {
             return "NOT FOUND".getBytes();
         }

--- a/src/main/java/util/HeterogeneousContainer.java
+++ b/src/main/java/util/HeterogeneousContainer.java
@@ -1,0 +1,37 @@
+package util;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class HeterogeneousContainer {
+    private final Map<String, Object> map;
+    public HeterogeneousContainer(Map<String, Object> map) {
+        this.map = map;
+    }
+    public void put(String key, String value) {
+        map.put(key, value);
+    }
+    public Optional<String> get(String key) {
+        Object value = map.get(key);
+        if (!(value instanceof String)) {
+            return Optional.empty();
+        }
+        return Optional.of((String) value) ;
+    }
+    public <T> void put(String key, T value, Class<T> type) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+        map.put(key, value);
+    }
+    public <T> Optional<T> get(String key, Class<T> type) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(type);
+        Object value = map.get(key);
+        if (!type.isInstance(value)) {
+            return Optional.empty();
+        }
+        type.cast(value);
+        return Optional.of(type.cast(value));
+    }
+}

--- a/src/main/java/webserver/HTTPMessageParser.java
+++ b/src/main/java/webserver/HTTPMessageParser.java
@@ -9,6 +9,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 
 public class HTTPMessageParser {
@@ -29,12 +31,10 @@ public class HTTPMessageParser {
         BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
         StringBuilder sb = new StringBuilder();
         HTTPRequest.Builder builder = new HTTPRequest.Builder();
+        Map<String, String> headers = new LinkedHashMap<>();
         try {
             parseFirstLine(reader, sb, builder);
-            String line;
-            do {
-                line = readLineWithLog(reader, sb);
-            } while (line != null && !line.isBlank());
+            readHeader(reader, sb, headers);
         } catch (IOException ioException) {
             logger.error(ioException.getMessage());
         }
@@ -62,5 +62,19 @@ public class HTTPMessageParser {
         requestBuilder.method(splited[0]);
         requestBuilder.uri(splited[1]);
         requestBuilder.version(splited[2]);
+    }
+
+    private void readHeader(BufferedReader reader, StringBuilder logBuilder, Map<String, String> headers)
+            throws IOException {
+        String line = readLineWithLog(reader, logBuilder);
+        while (line != null && !line.isBlank()) {
+            String [] splited = line.split(":");
+            if (splited.length != 2) {
+                throw new ParseException("Not valid request header.");
+            }
+            splited[0] = splited[0].trim().toLowerCase();
+            headers.put(splited[0], splited[1]);
+            line = readLineWithLog(reader, logBuilder);
+        }
     }
 }

--- a/src/main/java/webserver/HTTPMessageParser.java
+++ b/src/main/java/webserver/HTTPMessageParser.java
@@ -3,7 +3,9 @@ package webserver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import util.HeterogeneousContainer;
 import webserver.message.HTTPRequest;
+import webserver.message.header.HeaderParseManager;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -35,6 +37,8 @@ public class HTTPMessageParser {
         try {
             parseFirstLine(reader, sb, builder);
             readHeader(reader, sb, headers);
+            HeterogeneousContainer parsedHeaders = HeaderParseManager.getInstance().parse(headers);
+            builder.setHeaders(parsedHeaders);
         } catch (IOException ioException) {
             logger.error(ioException.getMessage());
         }
@@ -68,8 +72,9 @@ public class HTTPMessageParser {
             throws IOException {
         String line = readLineWithLog(reader, logBuilder);
         while (line != null && !line.isBlank()) {
-            String [] splited = line.split(":");
+            String [] splited = line.split(":", 2);
             if (splited.length != 2) {
+                logger.debug(logBuilder.toString());
                 throw new ParseException("Not valid request header.");
             }
             splited[0] = splited[0].trim().toLowerCase();

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -30,7 +30,7 @@ public class RequestHandler implements Runnable {
             HTTPRequest request = parser.parse(in);
             DataOutputStream dos = new DataOutputStream(out);
             ResourceResolver resolver = StaticResourceResolver.getInstance();
-            byte[] body = resolver.resolve(request.getUri());
+            byte[] body = resolver.resolve(request);
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import resolver.ResourceResolver;
 import resolver.StaticResourceResolver;
 import webserver.message.HTTPRequest;
+import webserver.message.HTTPResponse;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
@@ -28,30 +29,12 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             HTTPMessageParser parser = HTTPMessageParser.getInstance();
             HTTPRequest request = parser.parse(in);
+            HTTPResponse.Builder responseBuilder = new HTTPResponse.Builder();
             DataOutputStream dos = new DataOutputStream(out);
             ResourceResolver resolver = StaticResourceResolver.getInstance();
-            byte[] body = resolver.resolve(request);
-            response200Header(dos, body.length);
-            responseBody(dos, body);
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
-        try {
-            dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
-            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void responseBody(DataOutputStream dos, byte[] body) {
-        try {
-            dos.write(body, 0, body.length);
+            resolver.resolve(request, responseBuilder);
+            HTTPResponse response = responseBuilder.build();
+            ResponseWriter.write(dos, request, response);
             dos.flush();
         } catch (IOException e) {
             logger.error(e.getMessage());

--- a/src/main/java/webserver/ResponseWriter.java
+++ b/src/main/java/webserver/ResponseWriter.java
@@ -1,0 +1,59 @@
+package webserver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import webserver.message.HTTPRequest;
+import webserver.message.HTTPResponse;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class ResponseWriter {
+    private static final Logger logger = LoggerFactory.getLogger(ResponseWriter.class);
+
+    static private class ResponseStringBuilder {
+        StringBuilder sb = new StringBuilder();
+
+        void append(String str) {
+            sb.append(str);
+        }
+        void appendWithSpace(String str) {
+            sb.append(str);
+            sb.append(" ");
+        }
+
+        void appendHeader(String name, String value) {
+            sb.append(name);
+            sb.append(": ");
+            sb.append(value);
+            appendNewLine();
+        }
+        void appendLine(String line) {
+            sb.append(line);
+            sb.append("\r\n");
+        }
+        void appendNewLine() {
+            sb.append("\r\n");
+        }
+        String build() {
+            return sb.toString();
+        }
+    }
+
+    static void write(DataOutputStream out, HTTPRequest request, HTTPResponse response) {
+        ResponseStringBuilder builder = new ResponseStringBuilder();
+        try {
+            builder.appendWithSpace(request.getVersion().toString());
+            builder.appendWithSpace(response.getStatusCode().toString());
+            builder.appendNewLine();
+            builder.appendHeader("Content-Type", response.getContentType().toString());
+            builder.appendHeader("Content-Length", String.valueOf(response.getBody().length));
+            builder.appendNewLine();
+            out.writeBytes(builder.build());
+            out.write(response.getBody(), 0, response.getBody().length);
+            logger.debug("Response : {} {}", request.getUri(), response.getContentType());
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/webserver/ResponseWriter.java
+++ b/src/main/java/webserver/ResponseWriter.java
@@ -51,7 +51,6 @@ public class ResponseWriter {
             builder.appendNewLine();
             out.writeBytes(builder.build());
             out.write(response.getBody(), 0, response.getBody().length);
-            logger.debug("Response : {} {}", request.getUri(), response.getContentType());
         } catch (IOException e) {
             logger.error(e.getMessage());
         }

--- a/src/main/java/webserver/enumeration/HTTPContentType.java
+++ b/src/main/java/webserver/enumeration/HTTPContentType.java
@@ -1,0 +1,61 @@
+package webserver.enumeration;
+
+public enum HTTPContentType {
+    ALL("*", "*"),
+    TEXT("text", "*"),
+    TEXT_PLAIN("text", "plain"),
+    TEXT_HTML("text", "html", "htm"),
+    TEXT_CSS("text", "css"),
+    TEXT_JAVASCRIPT("text", "javascript"),
+
+    IMAGE("image", "*"),
+    IMAGE_PNG("image", "png"),
+    IMAGE_JPEG("image", "jpeg", "jpe", "jpg"),
+    IMAGE_GIF("image", "gif"),
+    IMAGE_ICON("image", "x-icon", "ico"),
+    APPLICATION_JSON("application", "json"),
+    APPLICATION_OCTET_STREAM("application", "octet-stream");
+
+    public final String primary;
+    public final String detail;
+    final String [] alias;
+
+    public static HTTPContentType DEFAULT_TYPE() {
+        return APPLICATION_OCTET_STREAM;
+    }
+
+    HTTPContentType(String primary, String detail, String ... alias) {
+        this.primary = primary;
+        this.detail = detail;
+        this.alias = alias;
+    }
+
+    @Override
+    public String toString() {
+        return primary + "/" + detail;
+    }
+
+    public static HTTPContentType fromDetailType(String postfix) {
+        for (HTTPContentType contentType : values()) {
+            if (contentType.detail.equals(postfix)) {
+                return contentType;
+            }
+            if (contentType.alias != null) {
+                for (String alias : contentType.alias) {
+                    if (alias.equals(postfix)) {
+                        return contentType;
+                    }
+                }
+            }
+        }
+        return DEFAULT_TYPE();
+    }
+
+    public static HTTPContentType fromFullType(String accept) {
+        String [] types = accept.split("/");
+        if (types.length == 2) {
+            return fromDetailType(types[1]);
+        }
+        return DEFAULT_TYPE();
+    }
+}

--- a/src/main/java/webserver/enumeration/HTTPContentType.java
+++ b/src/main/java/webserver/enumeration/HTTPContentType.java
@@ -13,6 +13,10 @@ public enum HTTPContentType {
     IMAGE_JPEG("image", "jpeg", "jpe", "jpg"),
     IMAGE_GIF("image", "gif"),
     IMAGE_ICON("image", "x-icon", "ico"),
+    IMAGE_SVG("image", "svg+xml", "svg"),
+    IMAGE_WEBP("image", "webp"),
+    IMAGE_APNG("image", "apng"),
+    IMAGE_AVIF("image", "avif"),
     APPLICATION_JSON("application", "json"),
     APPLICATION_OCTET_STREAM("application", "octet-stream");
 
@@ -57,5 +61,9 @@ public enum HTTPContentType {
             return fromDetailType(types[1]);
         }
         return DEFAULT_TYPE();
+    }
+
+    public static boolean isSupported(String accept) {
+        return fromFullType(accept) != DEFAULT_TYPE();
     }
 }

--- a/src/main/java/webserver/enumeration/HTTPContentType.java
+++ b/src/main/java/webserver/enumeration/HTTPContentType.java
@@ -22,7 +22,7 @@ public enum HTTPContentType {
 
     public final String primary;
     public final String detail;
-    final String [] alias;
+    public final String [] alias;
 
     public static HTTPContentType DEFAULT_TYPE() {
         return APPLICATION_OCTET_STREAM;

--- a/src/main/java/webserver/enumeration/HTTPStatusCode.java
+++ b/src/main/java/webserver/enumeration/HTTPStatusCode.java
@@ -1,0 +1,21 @@
+package webserver.enumeration;
+
+public enum HTTPStatusCode {
+    OK(200, "OK"),
+    CREATED(201, "Created"),
+    NOT_FOUND(404, "Not Found"),
+    SERVER_ERROR(500, "Internal Server Error");
+
+    final int code;
+    final String description;
+
+    HTTPStatusCode(int code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return code + " " + description;
+    }
+}

--- a/src/main/java/webserver/message/HTTPRequest.java
+++ b/src/main/java/webserver/message/HTTPRequest.java
@@ -41,6 +41,12 @@ public class HTTPRequest {
     public Map<String, String> getHeaders() {
         return headers;
     }
+    public Optional<String> getHeader(String name) {
+        if (!headers.containsKey(name)) {
+            return Optional.empty();
+        }
+        return Optional.of(headers.get(name));
+    }
 
     public static class Builder {
         private String method;

--- a/src/main/java/webserver/message/HTTPRequest.java
+++ b/src/main/java/webserver/message/HTTPRequest.java
@@ -1,7 +1,8 @@
 package webserver.message;
 
+import util.HeterogeneousContainer;
+
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -10,14 +11,14 @@ public class HTTPRequest {
     private String uri;
     private HTTPVersion version;
     private Optional<String> body;
-    private Map<String, String> headers;
+    private HeterogeneousContainer headers;
 
     public HTTPRequest(
             String method,
             String uri,
             HTTPVersion version,
             Optional<String> body,
-            Map<String, String> headers
+            HeterogeneousContainer headers
     ) {
         this.method = method;
         this.uri = uri;
@@ -38,14 +39,11 @@ public class HTTPRequest {
     public Optional<String> getBody() {
         return body;
     }
-    public Map<String, String> getHeaders() {
-        return headers;
-    }
     public Optional<String> getHeader(String name) {
-        if (!headers.containsKey(name)) {
-            return Optional.empty();
-        }
-        return Optional.of(headers.get(name));
+        return headers.get(name, String.class);
+    }
+    public <T> Optional<T> getHeader(String name, Class<T> type) {
+        return headers.get(name, type);
     }
 
     public static class Builder {
@@ -53,7 +51,7 @@ public class HTTPRequest {
         private String uri;
         private HTTPVersion version;
         private Optional<String> body;
-        private Map<String, String> headers = new LinkedHashMap<>();
+        private HeterogeneousContainer headers = new HeterogeneousContainer(new LinkedHashMap<>());
 
         public Builder() {
             this.body = Optional.empty();
@@ -83,11 +81,10 @@ public class HTTPRequest {
             this.body = Optional.ofNullable(body);
             return this;
         }
-        public Builder setHeader(String name, String value) {
-            this.headers.put(name, value);
+        public Builder setHeaders(HeterogeneousContainer headers) {
+            this.headers = headers;
             return this;
         }
-
         public HTTPRequest build() {
             return new HTTPRequest(method, uri, version, body, headers);
         }

--- a/src/main/java/webserver/message/HTTPResponse.java
+++ b/src/main/java/webserver/message/HTTPResponse.java
@@ -1,0 +1,60 @@
+package webserver.message;
+
+import webserver.enumeration.HTTPContentType;
+import webserver.enumeration.HTTPStatusCode;
+
+public class HTTPResponse {
+    static public class Builder {
+        private HTTPVersion version;
+        private HTTPStatusCode statusCode;
+        private HTTPContentType contentType = HTTPContentType.DEFAULT_TYPE();
+        private byte[] body;
+
+        public Builder version(HTTPVersion version) {
+            this.version = version;
+            return this;
+        }
+        public Builder statusCode(HTTPStatusCode statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+        public Builder contentType(HTTPContentType type) {
+            this.contentType = type;
+            return this;
+        }
+        public Builder contentTypeFromUri(String uri) {
+            final int lastDot = uri.lastIndexOf(".");
+            if (lastDot == -1) {
+                return this;
+            }
+            final String postfix = uri.substring(lastDot + 1);
+            this.contentType = HTTPContentType.fromDetailType(postfix);
+            return this;
+        }
+
+        public Builder body(byte[] body) {
+            this.body = body;
+            return this;
+        }
+
+        public HTTPResponse build() {
+            return new HTTPResponse(version, statusCode, contentType, body);
+        }
+    }
+    private final HTTPVersion version;
+    private final HTTPStatusCode statusCode;
+    private final HTTPContentType contentType;
+    private final byte[] body;
+
+    private HTTPResponse(HTTPVersion version, HTTPStatusCode statusCode, HTTPContentType contentType, byte[] body) {
+        this.version = version;
+        this.statusCode = statusCode;
+        this.contentType = contentType;
+        this.body = body;
+    }
+
+    public HTTPVersion getVersion() { return this.version; }
+    public HTTPStatusCode getStatusCode() { return this.statusCode; }
+    public HTTPContentType getContentType() { return this.contentType; }
+    public byte[] getBody() { return this.body; }
+}

--- a/src/main/java/webserver/message/header/HeaderParseManager.java
+++ b/src/main/java/webserver/message/header/HeaderParseManager.java
@@ -1,0 +1,37 @@
+package webserver.message.header;
+
+import util.HeterogeneousContainer;
+import webserver.message.header.parser.ContentTypeParser;
+import webserver.message.header.parser.HeaderParser;
+
+import java.util.LinkedHashMap;
+
+import java.util.Map;
+import java.util.Set;
+
+public class HeaderParseManager {
+    Map<String, HeaderParser> parsers;
+
+    private HeaderParseManager() {
+        this.parsers = Map.of("accept", new ContentTypeParser());
+    }
+    private static final HeaderParseManager INSTANCE = new HeaderParseManager();
+
+    public static HeaderParseManager getInstance() {
+        return INSTANCE;
+    }
+
+    public HeterogeneousContainer parse(Map<String, String> headers) {
+        Set<Map.Entry<String, String>> entries = headers.entrySet();
+        HeterogeneousContainer container = new HeterogeneousContainer(new LinkedHashMap<>());
+        for (Map.Entry<String, String> entry : entries) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            HeaderParser parser = parsers.get(key);
+            if (parser != null) {
+                parser.parse(container, value);
+            }
+        }
+        return container;
+    }
+}

--- a/src/main/java/webserver/message/header/parser/ContentTypeParser.java
+++ b/src/main/java/webserver/message/header/parser/ContentTypeParser.java
@@ -2,10 +2,28 @@ package webserver.message.header.parser;
 
 import util.HeterogeneousContainer;
 import webserver.enumeration.HTTPContentType;
+import webserver.message.header.records.AcceptRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ContentTypeParser implements HeaderParser {
+    private static final String ACCEPT_REGEX = "(?<ContentType>[^\\s,;]+/[^\\s,;]+)(?:;\\s*q=(?<qValue>[0-1].[0-9]+?))?";
+    private static final Pattern ACCEPT_PATTERN = Pattern.compile(ACCEPT_REGEX);
     @Override
     public void parse(HeterogeneousContainer headers, String value) {
+        Matcher matcher = ACCEPT_PATTERN.matcher(value);
+        List<AcceptRecord> records = new ArrayList<>();
+        while (matcher.find()) {
+            String contentType = matcher.group("ContentType");
+            String qValue = matcher.group("qValue");
+            float q = qValue != null ? Float.parseFloat(qValue) : 1.0f;
+            AcceptRecord record = new AcceptRecord(HTTPContentType.fromFullType(contentType), q);
+            records.add(record);
+        }
+        headers.put("accept", records.toArray(new AcceptRecord[]{records.get(0)}), AcceptRecord[].class);
         if (HTTPContentType.isSupported(value)) {
             throw new IllegalArgumentException("Unsupported content type");
         }

--- a/src/main/java/webserver/message/header/parser/ContentTypeParser.java
+++ b/src/main/java/webserver/message/header/parser/ContentTypeParser.java
@@ -1,0 +1,14 @@
+package webserver.message.header.parser;
+
+import util.HeterogeneousContainer;
+import webserver.enumeration.HTTPContentType;
+
+public class ContentTypeParser implements HeaderParser {
+    @Override
+    public void parse(HeterogeneousContainer headers, String value) {
+        if (HTTPContentType.isSupported(value)) {
+            throw new IllegalArgumentException("Unsupported content type");
+        }
+        headers.put("accept", HTTPContentType.fromFullType(value), HTTPContentType.class);
+    }
+}

--- a/src/main/java/webserver/message/header/parser/HeaderParser.java
+++ b/src/main/java/webserver/message/header/parser/HeaderParser.java
@@ -1,0 +1,7 @@
+package webserver.message.header.parser;
+
+import util.HeterogeneousContainer;
+
+public interface HeaderParser {
+    void parse(HeterogeneousContainer headers, String value);
+}

--- a/src/main/java/webserver/message/header/records/AcceptRecord.java
+++ b/src/main/java/webserver/message/header/records/AcceptRecord.java
@@ -1,0 +1,6 @@
+package webserver.message.header.records;
+
+import webserver.enumeration.HTTPContentType;
+
+public record AcceptRecord (HTTPContentType type, float qValue) {
+}


### PR DESCRIPTION
## 주요 변화
### HTTPRequest의 기타 header를 보관하기 위한 컨테이너 자료형 변화
HeterogeneousContainer로 특정 헤더를 사용하는 코드에서 타입을 지정하여 String 타입이 아닌 해당 타입으로 바로 얻을 수 있도록 하기 위함
이번에는 Accept 헤더에서 HTTPContentType으로 바꾼 결과를 그대로 사용하기 위해 사용됨.

### Resolver Interface 의 resolve 함수 시그니처 변화
요청을 처리할 때 request를 보면서 처리해야 하는 경우가 있어 변경함, HttpResponse.Builder 객체를 받도록 하여, 이 메서드에서 빌더를 생성하지 않아도 처리 기록을 남길수 있도록 함. (반환형으로 하면 다른 곳에서는 수정 불가)

### ResponseWriter 추가
HTTPResponse 객체를 HTTPResponseMessage 형식에 맞게 작성해주는 객체

## 계획
3번 구현 전에 1, 2주차 피드백을 반영 예정